### PR TITLE
fixed cfg windows

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -46,7 +46,7 @@ where
 {
   #[cfg(unix)]
   use std::os::unix::fs::symlink;
-  #[cfg(window)]
+  #[cfg(windows)]
   use std::os::windows::fs::symlink_dir as symlink;
 
   symlink(original, link)


### PR DESCRIPTION
On Windows compilation failed due to misspelled `cfg(windows)` leading to a "no such function" error for `symlink`