### PR TITLE
fix(dockerfile): git config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:0.1.59-rust-bullseye AS chef
+FROM lukemathwalker/cargo-chef:0.1.62-rust-bullseye AS chef
 WORKDIR /app
 
 FROM chef as planner
@@ -18,6 +18,13 @@ RUN cargo build --release --bin cargo-http-registry
 FROM debian:bullseye-slim as runner
 
 WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y git && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN git config --global user.name = "cargo-http-registry"
+RUN git config --global user.email = "cargo-http-registry@example.com"
 
 COPY --from=builder /app/target/release/cargo-http-registry /usr/local/bin
 ENTRYPOINT ["cargo-http-registry"]


### PR DESCRIPTION
The docker image doesn't work:
```sh
$ docker run  ghcr.io/d-e-s-o/cargo-http-registry:sha-1ede428 /tmp/hello
failed to create/instantiate crate index at /tmp/hello

Caused by:
    0: failed to create initial git commit
    1: failed to retrieve git signature object
    2: config value 'user.name' was not found; class=Config (7); code=NotFound (-3)
```

This PR fixes it 👍 