### PR TITLE
Strip registry root from `file` in `Index::add()` unconditionally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "git2",
  "headers",
  "openssl-sys",
+ "pathdiff",
  "pkg-config",
  "serde",
  "serde_json",
@@ -614,6 +615,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ tracing-subscriber = {version = "0.3", default-features = false, features = ["an
 warp = {version = "0.3", default-features = false}
 
 [dev-dependencies]
+pathdiff = "0.2"
 tempfile = {version = "3.1"}
 tokio = {version = "1.34", default-features = false, features = ["macros", "rt"]}
 


### PR DESCRIPTION
Hi!

That PR removes the `.is_relative()` check from `Index::add()`. The cause for this is that in my tests when started with the relative path as registry root (e.g. `cargo-http-registry crates-local` publishing crates to such registry fails with:
```
error: failed to publish to registry at http://127.0.0.1:34245

Caused by:
  the remote server responded with an error: failed to add crates-local/3/t/ttt to git repository, failed to add file to git index, could not find '/home/user/projects/crates-local/crates-local/3/t/ttt' to stat: No such file or directory; class=Os (2); code=NotFound (-3)
```
So the `crates-local` is duplicated. This is caused by the fact that when constructing `crate_meta_path` the base is index root (`crates-local`) which makes the whole `crate_meta_path` also relative. Then adding it fails because the stripping of the index root is not performed.

An alternative solution could probably be to avoid calling `Index::add` with the paths that contain index root, but I haven't investigated this too much.